### PR TITLE
Net - add three remaining help topics

### DIFF
--- a/net.lua
+++ b/net.lua
@@ -28,7 +28,7 @@ local net_parser = parser(
 
 local help_parser = parser(
     {
-        "help" .. parser(net_parser:flatten_argument(1))
+        "help" .. parser({net_parser:flatten_argument(1), "names", "services", "syntax"})
     }
 )
 


### PR DESCRIPTION
In addition to the individual subcommands, help has three more topics 
"names", "services", and "syntax", see net help.